### PR TITLE
chore: update readme and release from CI

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -47,4 +47,4 @@ jobs:
           MOMENTO_DDB_LOCK_VERSION: ${{ steps.semrel.outputs.version }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishToSonatype closeSonatypeStagingRepository
+          arguments: publishToSonatype closeAndReleaseStagingRepository

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ While advanced consensus algorithms like Raft and Paxos offer solutions to these
 
 ## Usage
 
+Install the dependency:
+
+```xml
+<dependency>
+  <groupId>software.momento.java</groupId>
+  <artifactId>momento-dynamodb-lock-client</artifactId>
+  <version>0.1.0</version>
+</dependency>
+```
+
+Initialize your client and start locking!
+
 ```java
 
 import com.amazonaws.services.dynamodbv2.AcquireLockOptions;


### PR DESCRIPTION
Added dependency info to README now that we have a release out, and also changed CI to not just upload artifacts to Sonatype but also release it automatically now that we have verified it.