### PR TITLE
chore: replace OSSRH endpoint with Sonatype Central endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,8 +107,8 @@ tasks.withType<io.github.gradlenexus.publishplugin.AbstractNexusStagingRepositor
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1236

OSSRH is reaching end of life on June 30, 2025, so we migrated our namespace to Sonatype Central namespace and we must accordingly update the endpoints for where to push deployments.